### PR TITLE
Fix Label summary calculation

### DIFF
--- a/client.js
+++ b/client.js
@@ -151,7 +151,7 @@ var getBoardButtons = function(t) {
                 var listSums = {};
                 var columnEntries = [];
                 cards.forEach(function(card, cardIdx){ 
-                  if (costArray[cardIdx]) {
+                  if (costArray[cardIdx] && costArray[cardIdx][idx]) {
                     if (card.labels.length > 0) {
                       card.labels.forEach(function(label) {
                         var displayName = label.name || label.color;


### PR DESCRIPTION
After entering a couple dozen costs in my board, I noticed the `summaryByLabel` calculation was displayed as `NaN` for some Labels. Some of those Labels had actual costs, and some of them had costs previously that I had removed. While stepping through the JS, it seemed like `costArray[cardIdx]` was sometimes, for example, an Array such as `[null, null, null]`. This evaluates to `true`, but then `parseFloat` on `null` results in `NaN`, which breaks the sum for that Label. This change avoids that result by only updating `listSums` if that cost exists for that Card.