### PR TITLE
Fix card badge refresh showing same cost on all cards (#47)

### DIFF
--- a/client.js
+++ b/client.js
@@ -11,12 +11,14 @@ var getBadges = function(t){
   // 4,000 character limit for trello data.  costs are now stored
   // in card level objects, and this is here to convert old board-
   // level costs to the new card-level objects
-  return t.card('id')
-  .then(function(card) {
+  var cardId = t.getContext().card;
+  if (!cardId) {
+    return [];
+  }
   return t.get('board', 'shared', 'costs')
   .then(function(oldCosts) {
     var returnCosts = function () {
-      return t.get('card', 'shared', 'costs')
+      return t.get(cardId, 'shared', 'costs')
       .then(function(costs){
       return t.get('board', 'shared', 'costFields')
       .then(function(costFields){
@@ -47,12 +49,9 @@ var getBadges = function(t){
             // is always the default title.
             var newCostArray = [];
             newCostArray.push(costs['Total Cost']);
-            return t.set('card', 'shared', 'costs', newCostArray)
+            return t.set(cardId, 'shared', 'costs', newCostArray)
             .then(function() {
-              return t.set('board','shared','refresh',Math.random())
-              .then(function() {
-                return getBadges(t);               
-              });
+              return getBadges(t);
             });
           }
         } else {
@@ -62,11 +61,12 @@ var getBadges = function(t){
       });
     }
     // oldcosts: these are legacy costs from v1 that were stored on the board-level object
-    if (oldCosts && oldCosts[card.id]) {
-      return t.set('card', 'shared', 'costs', [oldCosts[card.id]])
+    if (oldCosts && oldCosts[cardId]) {
+      return t.set(cardId, 'shared', 'costs', [oldCosts[cardId]])
       .then(function() {
-        delete oldCosts[card.id];
-        return t.set('board', 'shared', 'costs', oldCosts)
+        var remainingBoardCosts = Object.assign({}, oldCosts);
+        delete remainingBoardCosts[cardId];
+        return t.set('board', 'shared', 'costs', remainingBoardCosts)
         .then(function() {
           return returnCosts();
         });
@@ -74,7 +74,6 @@ var getBadges = function(t){
     } else {
       return returnCosts();
     }
-  });
   });
 };
 
@@ -357,14 +356,11 @@ var getButtons = function(t) {
                 text: !Number.isNaN(parseFloat(options.search)) ? 'Set ' + costFields[idx] + ' to ' + parseFloat(newCost).toLocaleString(undefined,{minimumFractionDigits:2}) : '(Enter a number to set ' + costFields[idx] + '.)',
                 callback: function(t) {
                   if (newCost != 'NaN') {
-                    var newCosts = costs ? costs : Array(costFields.length).fill(null);
+                    var newCosts = costs ? costs.slice() : Array(costFields.length).fill(null);
                     newCosts[idx] = newCost;
-                    return t.set('card','shared','costs', newCosts)
+                    return t.set('card', 'shared', 'costs', newCosts)
                     .then(function() {
-                      return t.set('board','shared','refresh',Math.random())
-                      .then(function() {
-                        return t.closePopup();
-                      });
+                      return t.closePopup();
                     });
                   }
                   return t.closePopup();
@@ -374,9 +370,9 @@ var getButtons = function(t) {
                 buttons.push({
                   text: 'Remove ' + costFields[idx] + '.',
                   callback: function(t) {
-                    var newCosts = costs ? costs : Array(costFields.length).fill(null);
+                    var newCosts = costs ? costs.slice() : Array(costFields.length).fill(null);
                     newCosts[idx] = null;
-                    t.set('card','shared','costs', newCosts);
+                    t.set('card', 'shared', 'costs', newCosts);
                     return t.closePopup();
                   }
                 });


### PR DESCRIPTION
After saving a cost, `board.shared.refresh` forced every card-badges callback to re-run. Use `t.getContext().card` in `getBadges`, remove the board-wide refresh on save, and clone cost arrays before mutating.